### PR TITLE
Add version and externalID to API

### DIFF
--- a/serverless_discovery_sdk/DiscoverySdk.py
+++ b/serverless_discovery_sdk/DiscoverySdk.py
@@ -8,9 +8,9 @@ class DiscoverySdk:
         self.defaultStageName = defaultStageName
         self.api = DiscoveryServiceApi(serviceEndpointUri, region, { 'type': 'None' })
 
-    def lookupService(self, ServiceName, StageName = ''):
-        if (len(StageName) == 0):
-            StageName = self.defaultStageName
+    def lookupService(self, serviceName, stageName = '', version = '', externalID = ''):
+        if (len(stageName) == 0):
+            stageName = self.defaultStageName
 
-        response = self.api.lookupService(ServiceName, StageName)
+        response = self.api.lookupService(serviceName, stageName, version, externalID)
         return response

--- a/serverless_discovery_sdk/DiscoverySdk.py
+++ b/serverless_discovery_sdk/DiscoverySdk.py
@@ -8,9 +8,9 @@ class DiscoverySdk:
         self.defaultStageName = defaultStageName
         self.api = DiscoveryServiceApi(serviceEndpointUri, region, { 'type': 'None' })
 
-    def lookupService(self, ServiceName, StageName = ''):
+    def lookupService(self, serviceName, stageName = '', version = '', externalID = ''):
         if (len(StageName) == 0):
             StageName = self.defaultStageName
 
-        response = self.api.lookupService(ServiceName, StageName)
+        response = self.api.lookupService(serviceName, stageName, version, externalID)
         return response

--- a/serverless_discovery_sdk/DiscoveryServiceApi.py
+++ b/serverless_discovery_sdk/DiscoveryServiceApi.py
@@ -10,9 +10,9 @@ class DiscoveryServiceApi:
         self.region = region
         self.defaultStageName = defaultStageName
 
-    def lookupService(self, ServiceName, StageName = ''):
+    def lookupService(self, serviceName, stageName = '', version = '', externalID = ''):
         url = '%s/catalog/service' % (self.serviceEndpointUri)
-        response = self.session.get(url, params = { 'ServiceName': ServiceName, 'StageName': StageName })
+        response = self.session.get(url, params = { 'ServiceName': serviceName, 'StageName': stageName, 'Version': version, 'ExternalID': externalID })
         body = response.json()
         if response.status_code == 200:
             return list(map(lambda service: service['ServiceURL'], body))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="serverless-discovery-sdk",
-    version="0.1.0",
+    version="1.0.0",
     author="Andrew Regier",
     author_email="aregier@regiernet.com",
     description="Serverless Service Discovery SDK",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="serverless-discovery-sdk",
-    version="0.0.5",
+    version="0.1.0",
     author="Andrew Regier",
     author_email="aregier@regiernet.com",
     description="Serverless Service Discovery SDK",


### PR DESCRIPTION
Adds the ability (should be backwards compatible once implemented in the service) to filter services by version # and an externalID field